### PR TITLE
Added a download link for Electron app

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
     <a class="margin-x" href="/">
       <img class="logo" src="media/logo.svg" />
     </a>
-    <div class="nav-container">
-      <a href="#" class="nav-link" id="download" hidden>Download App</a>
-      <a class="nav-link margin-x" target="_blank"
+    <div>
+      <a href="#" id="download" hidden>Download App</a>
+      <a class="margin-x" target="_blank"
         href="https://github.com/georgemandis/recurse-roulette-server">Github</a>
     </div>
   </nav>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       <img class="logo" src="media/logo.svg" />
     </a>
     <div class="nav-container">
+      <a href="#" class="nav-link" id="download" hidden>Download App</a>
       <a class="nav-link margin-x" target="_blank"
         href="https://github.com/georgemandis/recurse-roulette-server">Github</a>
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -453,3 +453,31 @@ function isConnected() {
       "<marquee scrollamount='20' behavior='alternate' style='width:30%;color:#00A0E6'>Gotta go fast!</marquee>";
   });
 })();
+
+/**
+ * Update the app download link if we're not already
+ * in the Electron app.
+ */
+if (!(navigator.userAgent.toLowerCase().indexOf(" electron/") > -1)) {
+  const appLinks = [
+    ["^mac", "https://teambeard.s3.amazonaws.com/recurse-roulette-1.0.0.dmg"],
+    [
+      "^win",
+      "https://teambeard.s3.amazonaws.com/recurse-roulette-setup-1.0.0.exe",
+    ],
+    [
+      "^linux",
+      "https://teambeard.s3.amazonaws.com/recurse-roulette-1.0.0.AppImage",
+    ],
+  ];
+
+  appLinks.forEach((platformCheck) => {
+    const check = new RegExp(platformCheck[0], "i");
+
+    if (!!check.test(navigator.platform)) {
+      const download = document.querySelector("#download");
+      download.href = platformCheck[1];
+      download.hidden = false;
+    }
+  });
+}


### PR DESCRIPTION
Added a prompt in the main navigation to download platform-specific Electron app. If you're on a platform it can't detect or you're already in the Electron app it shouldn't show the download link.